### PR TITLE
support loading channel 2 data in map from _ch2 files

### DIFF
--- a/pymapmanager/mmMap.py
+++ b/pymapmanager/mmMap.py
@@ -384,7 +384,7 @@ class mmMap():
 	def _getStackName(self, sessIdx):
 		# get the name of the stack at session sessIdx, this is contained in the map header
 		ret = self.getValue('hsStack', sessIdx)
-		if ret.endswith('_ch1'):
+		if ret.endswith('_ch1') or ret.endswith('_ch2'):
 			ret = ret[:-4]
 		return ret
 


### PR DESCRIPTION
I noticed that when trying to open files corresponding to channel 2, PyMapManager was not able to correctly identify the file names. It was only looking for the _ch1 prefix. This change should fix that and support both _ch1 and _ch2.